### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library can handle coil motors, stepper motors, lights, servos.
 category=Device Control
 url=https://github.com/Locoduino/Accessories
 architectures=*
+depends=DIO2, Servo, SX1509 IO Expander


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I have not added the ShiftRegister74HC595 dependency because a breaking change was made to that library's API in its 1.3.0 release, causing the Accessories to be incompatible with any version after 1.2.0. The Arduino Library Manager's dependency installation system currently only supports installing the newest available version of the dependencies. Once support for specifying version dependencies is added, or the Accessories library is updated to be compatible with the newest versions of the ShiftRegister74HC595 library, that should also be added to the `depends` field.